### PR TITLE
Fix detail title view jumping

### DIFF
--- a/Pod/Classes/TNKAssetsDetailViewController.m
+++ b/Pod/Classes/TNKAssetsDetailViewController.m
@@ -202,7 +202,8 @@ NSString *const TNKImagePickerControllerAssetViewControllerNotificationKey = @"A
     titleFrame.size = [_titleView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
     _titleView.frame = titleFrame;
 	
-	
+	self.navigationItem.titleView = nil;
+	self.navigationItem.titleView = _titleView;
 	
 	NSIndexPath *indexPath = [self.viewControllers.firstObject assetIndexPath];
 	BOOL selected = [self.assetDelegate assetsDetailViewController:self isAssetSelectedAtIndexPath:indexPath];


### PR DESCRIPTION
Seems like sometimes the changing frame of `TNKAssetDetailViewController`'s
`_titleView` isn't informing the navigation item's "view". Un-setting and re-
setting the `titleView` on the navigation item fixes this.
