### PR TITLE
Added an option to suppress the "Select All" button

### DIFF
--- a/Pod/Classes/TNKImagePickerController.h
+++ b/Pod/Classes/TNKImagePickerController.h
@@ -114,6 +114,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)selectAsset:(PHAsset *)asset;
 - (void)deselectAsset:(PHAsset *)asset;
 
+@property (nonatomic) bool hideSelectAll;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Pod/Classes/TNKImagePickerController.m
+++ b/Pod/Classes/TNKImagePickerController.m
@@ -144,6 +144,11 @@
     }
 }
 
+-(void) setHideSelectAll:(bool)hideSelectAll {
+    _hideSelectAll = hideSelectAll;
+    [self _updateToolbarItems:false];
+}
+
 - (void)_updateDoneButton {
     _doneButton.enabled = _selectedAssets.count > 0;
 	
@@ -203,7 +208,9 @@
     
     [items addObject:[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil]];
     
-    [items addObject:_selectAllButton];
+    if (!self.hideSelectAll) {
+        [items addObject:_selectAllButton];
+    }
     
     [self setToolbarItems:items animated:animated];
 }


### PR DESCRIPTION
The option to hide the "Select All" button is introduced when the App using this Library is not interested in selecting vast amounts of images. This is a first take on putting a limit to the number of selectable images.
