### PR TITLE
Present returned camera view controller

### DIFF
--- a/TNKImagePickerController/TNKImagePickerController.m
+++ b/TNKImagePickerController/TNKImagePickerController.m
@@ -380,7 +380,7 @@
     }
     
     if (viewController != nil) {
-        [self presentViewController:imagePicker animated:YES completion:nil];
+        [self presentViewController:viewController animated:YES completion:nil];
     }
 }
 


### PR DESCRIPTION
Previously, the returned camera view controller was ignored, and only checked against `nil` to see whether to present the default camera view controller. Updated that to use the returned camera view controller instead.
