### PR TITLE
Reapply "jumping detail title view" fix

### DIFF
--- a/TNKImagePickerController/TNKAssetsDetailViewController.m
+++ b/TNKImagePickerController/TNKAssetsDetailViewController.m
@@ -202,7 +202,9 @@ NSString *const TNKImagePickerControllerAssetViewControllerNotificationKey = @"A
     titleFrame.size = [_titleView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
     _titleView.frame = titleFrame;
 	
-	
+    // Fix detail title view jumping
+    self.navigationItem.titleView = nil;
+    self.navigationItem.titleView = _titleView;
 	
 	NSIndexPath *indexPath = [self.viewControllers.firstObject assetIndexPath];
 	BOOL selected = [self.assetDelegate assetsDetailViewController:self isAssetSelectedAtIndexPath:indexPath];


### PR DESCRIPTION
Seems to have been reverted in the project reorganization since #16 was merged.
