### PR TITLE
Assets collections fixes

### DIFF
--- a/TNKImagePickerController/TNKAssetCollectionViewController.h
+++ b/TNKImagePickerController/TNKAssetCollectionViewController.h
@@ -11,12 +11,17 @@
 @class PHAssetCollection;
 @class PHFetchResult;
 
+typedef NS_ENUM(NSInteger, TNKAssetCollectionViewFlowLayoutType) {
+	TNKAssetCollectionViewFlowLayoutTypeDefault,
+	TNKAssetCollectionViewFlowLayoutTypeInverted
+};
 
 @interface TNKAssetCollectionViewController : TNKCollectionViewController
 
 @property (nonatomic, nonnull, readonly) PHAssetCollection *assetCollection;
 @property (nonatomic, nonnull, readonly) PHFetchResult *fetchResult;
+@property (nonatomic, readonly) TNKAssetCollectionViewFlowLayoutType flowlayoutType;
 
-- (nonnull instancetype)initWithAssetCollection:(nonnull PHAssetCollection *)assetCollection;
+- (nonnull instancetype)initWithAssetCollection:(nonnull PHAssetCollection *)assetCollection flowlayoutType:(TNKAssetCollectionViewFlowLayoutType)flowlayoutType;
 
 @end

--- a/TNKImagePickerController/TNKAssetCollectionViewController.m
+++ b/TNKImagePickerController/TNKAssetCollectionViewController.m
@@ -20,6 +20,7 @@
 #import "NSDate+TNKFormattedDay.h"
 #import "UIImage+TNKIcons.h"
 #import "TNKAssetSelection.h"
+#import "TNKCollectionViewInvertedFlowLayout.h"
 
 
 @interface TNKAssetCollectionViewController ()
@@ -29,12 +30,20 @@
 @implementation TNKAssetCollectionViewController
 
 @synthesize fetchResult = _fetchResult;
+@synthesize flowlayoutType = _flowlayoutType;
 
 - (void)setLayoutInsets:(UIEdgeInsets)layoutInsets {
 	[super setLayoutInsets:layoutInsets];
-	
-	self.collectionView.contentInset = layoutInsets;
-	self.collectionView.scrollIndicatorInsets = layoutInsets;
+
+	if (_flowlayoutType == TNKAssetCollectionViewFlowLayoutTypeInverted) {
+		// because we invert scrolling our top is actually our bottom and vice versa
+		self.collectionView.contentInset = UIEdgeInsetsMake(layoutInsets.bottom, 0, layoutInsets.top, 0);
+		self.collectionView.scrollIndicatorInsets = self.collectionView.contentInset;
+	}
+	else {
+		self.collectionView.contentInset = layoutInsets;
+		self.collectionView.scrollIndicatorInsets = layoutInsets;
+	}
 }
 
 - (UICollectionViewFlowLayout *)_layout {
@@ -64,15 +73,24 @@
 
 #pragma mark - Initialization
 
-- (instancetype)initWithAssetCollection:(PHAssetCollection *)assetCollection
+- (nonnull instancetype)initWithAssetCollection:(nonnull PHAssetCollection *)assetCollection flowlayoutType:(TNKAssetCollectionViewFlowLayoutType)flowlayoutType
 {
-	UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+	UICollectionViewFlowLayout *layout = nil;
+	
+	if (flowlayoutType == TNKAssetCollectionViewFlowLayoutTypeInverted) {
+		layout = [[TNKCollectionViewInvertedFlowLayout alloc] init];
+	}
+	else {
+		layout = [[UICollectionViewFlowLayout alloc] init];
+	}
+	
 	layout.minimumLineSpacing = TNKObjectSpacing;
 	layout.minimumInteritemSpacing = 0.0;
 	
 	self = [super initWithCollectionViewLayout:layout];
 	if (self != nil) {
 		_assetCollection = assetCollection;
+		_flowlayoutType = flowlayoutType;
 	}
 	
 	return self;
@@ -83,6 +101,10 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+	
+	if (_flowlayoutType == TNKAssetCollectionViewFlowLayoutTypeInverted) {
+		self.collectionView.transform = TNKInvertedTransform;
+	}
 	
 	_fetchResult = [PHAsset fetchAssetsInAssetCollection:_assetCollection options:[self assetFetchOptions]];
 	

--- a/TNKImagePickerController/TNKCollectionPickerController.m
+++ b/TNKImagePickerController/TNKCollectionPickerController.m
@@ -142,8 +142,7 @@ NSString * const TNKMomentsSection = @"Moments";
         
         if (collectionList == nil) {
 			fetchResults = @[
-							 [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:PHAssetCollectionSubtypeAlbumMyPhotoStream options:nil],
-							 
+							 [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumUserLibrary options:nil],
 							 [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumFavorites options:nil],
 							 [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumGeneric options:nil],
 							 [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumSelfPortraits options:nil],

--- a/TNKImagePickerController/TNKImagePickerController.m
+++ b/TNKImagePickerController/TNKImagePickerController.m
@@ -103,7 +103,19 @@
 	if (_assetCollection == nil) {
 		self.collectionViewController = self.momentsViewController;
 	} else {
-		self.collectionViewController = [[TNKAssetCollectionViewController alloc] initWithAssetCollection:_assetCollection];
+		
+		TNKAssetCollectionViewFlowLayoutType assetCollectionFlowType;
+		
+		switch (assetCollection.assetCollectionType) {
+			case PHAssetCollectionTypeSmartAlbum:
+				assetCollectionFlowType = TNKAssetCollectionViewFlowLayoutTypeInverted;
+				break;
+			default:
+				assetCollectionFlowType = TNKAssetCollectionViewFlowLayoutTypeDefault;
+				break;
+		}
+		
+		self.collectionViewController = [[TNKAssetCollectionViewController alloc] initWithAssetCollection:_assetCollection flowlayoutType:assetCollectionFlowType];
 	}
     
     [self _updateForAssetCollection];


### PR DESCRIPTION
- adding back `PHAssetCollectionSubtypeSmartAlbumUserLibrary` (All
Photos album) to the collection list (was removed in previous version)

- implementing possibility to choose flow layout (Inverted, Default)
when initializing `TNKAssetCollectionViewController`

- using `TNKAssetCollectionViewFlowLayoutTypeInverted` for
`PHAssetCollectionTypeSmartAlbum` to simulate same behavior as in the
stock Apple Photo app

- removing duplicated `PHAssetCollectionSubtypeAlbumMyPhotoStream `
from the collection list